### PR TITLE
Remove the #MemoryLogger >> shallowCopy method

### DIFF
--- a/FFICallLogger/DateAndTime.extension.st
+++ b/FFICallLogger/DateAndTime.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #DateAndTime }
+Extension { #name : 'DateAndTime' }
 
-{ #category : #'*FFICallLogger' }
+{ #category : '*FFICallLogger' }
 DateAndTime class >> fromMicrosecondClockValue: anInteger [
 
 	| nanoTicks |

--- a/FFICallLogger/ExternalAddress.extension.st
+++ b/FFICallLogger/ExternalAddress.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #ExternalAddress }
+Extension { #name : 'ExternalAddress' }
 
-{ #category : #'*FFICallLogger' }
+{ #category : '*FFICallLogger' }
 ExternalAddress >> asTFLRecording [
 	"Self is mutated on free as null, so answer a new object that won't change."
 

--- a/FFICallLogger/MemoryLogger.extension.st
+++ b/FFICallLogger/MemoryLogger.extension.st
@@ -1,20 +1,13 @@
-Extension { #name : #MemoryLogger }
+Extension { #name : 'MemoryLogger' }
 
-{ #category : #'*FFICallLogger' }
+{ #category : '*FFICallLogger' }
 MemoryLogger >> initializeWithRecordings: aCollection [
 	"Set the collection as the recordings. Assumes that #initialize was called before."
 
 	recordings := aCollection
 ]
 
-{ #category : #'*FFICallLogger' }
-MemoryLogger >> shallowCopy [
-
-	"The #recordings accessor answers a copy of the internal collection."
-	^ self class withRecordings: self recordings
-]
-
-{ #category : #'*FFICallLogger' }
+{ #category : '*FFICallLogger' }
 MemoryLogger class >> withRecordings: aCollection [
 
 	^ self new

--- a/FFICallLogger/Object.extension.st
+++ b/FFICallLogger/Object.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Object }
+Extension { #name : 'Object' }
 
-{ #category : #'*FFICallLogger' }
+{ #category : '*FFICallLogger' }
 Object >> asTFLRecording [
 
 	^ self

--- a/FFICallLogger/TFLAddress.class.st
+++ b/FFICallLogger/TFLAddress.class.st
@@ -5,13 +5,15 @@ A bit more precisely: I'm a copy of the address that isn't supposed to change fo
 
 "
 Class {
-	#name : #TFLAddress,
-	#superclass : #ByteArray,
-	#type : #bytes,
-	#category : #'FFICallLogger-Recordings'
+	#name : 'TFLAddress',
+	#superclass : 'ByteArray',
+	#type : 'bytes',
+	#category : 'FFICallLogger-Recordings',
+	#package : 'FFICallLogger',
+	#tag : 'Recordings'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 TFLAddress class >> newFrom: anExternalAddress [
 
 	| sz |
@@ -21,14 +23,14 @@ TFLAddress class >> newFrom: anExternalAddress [
 		yourself
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 TFLAddress >> asString [
 	"Answer a string that represents the receiver."
 
 	^ self printString
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 TFLAddress >> printOn: aStream [
 	"Print a lowercase hexadecimal String representation of my 4 higher bytes, prefixed by @."
 

--- a/FFICallLogger/TFLCallLogger.class.st
+++ b/FFICallLogger/TFLCallLogger.class.st
@@ -18,30 +18,32 @@ Other useful statements:
 ```
 "
 Class {
-	#name : #TFLCallLogger,
-	#superclass : #CircularMemoryLogger,
+	#name : 'TFLCallLogger',
+	#superclass : 'CircularMemoryLogger',
 	#instVars : [
 		'filters',
 		'numberOfFilteredSignals'
 	],
-	#category : #'FFICallLogger-Core'
+	#category : 'FFICallLogger-Core',
+	#package : 'FFICallLogger',
+	#tag : 'Core'
 }
 
-{ #category : #'system startup' }
+{ #category : 'system startup' }
 TFLCallLogger class >> startUp: resuming [
 	"If starting the image, all external addresses should be zero then we remove them."
 
 	resuming ifTrue: [ self resetInstance ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLCallLogger >> addFilter: aClosureThatReceivesSignalAndAnswersBoolean [
 
 	filters := filters copyWith: aClosureThatReceivesSignalAndAnswersBoolean.
 	self announceChanged.
 ]
 
-{ #category : #convenience }
+{ #category : 'convenience' }
 TFLCallLogger >> addFilter: accessor deny: value [
 	"Add a filter like '[ :signal | signal <accessor> ~= <value> ]'"
 
@@ -51,7 +53,7 @@ TFLCallLogger >> addFilter: accessor deny: value [
 
 ]
 
-{ #category : #convenience }
+{ #category : 'convenience' }
 TFLCallLogger >> addFilter: accessor equals: value [
 	"Add a filter like '[ :signal | signal <accessor> = <value> ]'"
 
@@ -60,7 +62,7 @@ TFLCallLogger >> addFilter: accessor equals: value [
 	self addFilterByCompiling: body
 ]
 
-{ #category : #convenience }
+{ #category : 'convenience' }
 TFLCallLogger >> addFilterByCompiling: body [
 	"Add a filter like '[ :signal | <body> ]'"
 
@@ -72,7 +74,7 @@ TFLCallLogger >> addFilterByCompiling: body [
 
 ]
 
-{ #category : #convenience }
+{ #category : 'convenience' }
 TFLCallLogger >> addFilterHasArgumentLike: value [
 	"Add a filter for calls with at least one argument that converted to string equals to <value> as string."
 
@@ -82,7 +84,7 @@ TFLCallLogger >> addFilterHasArgumentLike: value [
 	self addFilterByCompiling: body
 ]
 
-{ #category : #convenience }
+{ #category : 'convenience' }
 TFLCallLogger >> addFilterSignalsLike: aTFLSignal [ 
 	
 	| body |
@@ -90,7 +92,7 @@ TFLCallLogger >> addFilterSignalsLike: aTFLSignal [
 	self addFilterByCompiling: body
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 TFLCallLogger >> announceChanged [
 
 	"Workaround as this message is sent during initialization."
@@ -99,7 +101,7 @@ TFLCallLogger >> announceChanged [
 	announcer announce: (ValueChanged newValue: self)
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 TFLCallLogger >> basicReset [
 
 	super basicReset.
@@ -107,20 +109,20 @@ TFLCallLogger >> basicReset [
 	self announceChanged.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLCallLogger >> filters [
 
 	^ filters
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLCallLogger >> filters: aCollection [
 
 	filters := aCollection.
 	self announceChanged.
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 TFLCallLogger >> initialize [ 
 
 	super initialize.
@@ -128,7 +130,7 @@ TFLCallLogger >> initialize [
 	self resetFilteredSignals.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLCallLogger >> nextPut: aTFLSignal [
 
 	aTFLSignal prepareAsRecording. "TODO: argument filtering need to prepare not-lazily"
@@ -142,13 +144,13 @@ TFLCallLogger >> nextPut: aTFLSignal [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLCallLogger >> numberOfFilteredSignals [
 
 	^ numberOfFilteredSignals
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLCallLogger >> removeFilter: aUnaryBlockClosure [
 	"Remove a filter. We support sending this message from a closure iterating the filters."
 
@@ -156,20 +158,20 @@ TFLCallLogger >> removeFilter: aUnaryBlockClosure [
 	self announceChanged.
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 TFLCallLogger >> resetFilteredSignals [
 
 	numberOfFilteredSignals := 0.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLCallLogger >> resetFilters [
 
 	filters := {}.
 	self announceChanged.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLCallLogger >> shouldRecord: aSignal [
 
 	^ filters noneSatisfy: [ :each |
@@ -181,14 +183,14 @@ TFLCallLogger >> shouldRecord: aSignal [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLCallLogger >> start [
 
 	self startFor: TFLSignal.
 	self announceChanged
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLCallLogger >> stop [
 
 	super stop.

--- a/FFICallLogger/TFLFunctionCounter.class.st
+++ b/FFICallLogger/TFLFunctionCounter.class.st
@@ -15,23 +15,25 @@ a Dictionary [8 items] (#SDL_GetModState->62 #SDL_GetMouseState->34 #SDL_GetWind
 ```
 "
 Class {
-	#name : #TFLFunctionCounter,
-	#superclass : #SignalLogger,
+	#name : 'TFLFunctionCounter',
+	#superclass : 'SignalLogger',
 	#instVars : [
 		'queue',
 		'bagOfFunctionNames'
 	],
-	#category : #'FFICallLogger-Counter'
+	#category : 'FFICallLogger-Counter',
+	#package : 'FFICallLogger',
+	#tag : 'Counter'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLFunctionCounter >> functionNamesAndCounts [
 
 	self process.
 	^ bagOfFunctionNames valuesAndCounts
 ]
 
-{ #category : #registering }
+{ #category : 'registering' }
 TFLFunctionCounter >> initialize [
 
 	super initialize.
@@ -40,14 +42,14 @@ TFLFunctionCounter >> initialize [
 	bagOfFunctionNames := Bag new.
 ]
 
-{ #category : #registering }
+{ #category : 'registering' }
 TFLFunctionCounter >> nextPut: aTFLSignal [
 	"Store fast in a waitfree collection. To be processed on demand."
 	
 	queue nextPut: aTFLSignal functionName
 ]
 
-{ #category : #API }
+{ #category : 'API' }
 TFLFunctionCounter >> process [
 
 	| queueToProcess |
@@ -62,7 +64,7 @@ TFLFunctionCounter >> process [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLFunctionCounter >> start [
 
 	self startFor: TFLSignal

--- a/FFICallLogger/TFLFunctionCyclicCounter.class.st
+++ b/FFICallLogger/TFLFunctionCyclicCounter.class.st
@@ -32,23 +32,25 @@ Now, `Transcript` should be showing something like:
 
 "
 Class {
-	#name : #TFLFunctionCyclicCounter,
-	#superclass : #Object,
+	#name : 'TFLFunctionCyclicCounter',
+	#superclass : 'Object',
 	#instVars : [
 		'announcer',
 		'delay',
 		'loopProcess'
 	],
-	#category : #'FFICallLogger-Counter'
+	#category : 'FFICallLogger-Counter',
+	#package : 'FFICallLogger',
+	#tag : 'Counter'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 TFLFunctionCyclicCounter class >> newEvery: aDuration [
 
 	^ self newEveryMilliseconds: aDuration asMilliSeconds
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 TFLFunctionCyclicCounter class >> newEveryMilliseconds: msToWait [
 
 	^ self basicNew
@@ -56,13 +58,13 @@ TFLFunctionCyclicCounter class >> newEveryMilliseconds: msToWait [
 		  yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLFunctionCyclicCounter >> announcer [
 
 	^ announcer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLFunctionCyclicCounter >> forkLoopProcess [
 
 	loopProcess := [
@@ -95,7 +97,7 @@ TFLFunctionCyclicCounter >> forkLoopProcess [
 
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 TFLFunctionCyclicCounter >> initializeWithMilliseconds: millisecondsToWait [
 
 	self initialize.
@@ -104,7 +106,7 @@ TFLFunctionCyclicCounter >> initializeWithMilliseconds: millisecondsToWait [
 	delay := Delay forMilliseconds: millisecondsToWait.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLFunctionCyclicCounter >> start [
 
 	"Ensure installed on the system"
@@ -114,7 +116,7 @@ TFLFunctionCyclicCounter >> start [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLFunctionCyclicCounter >> stop [
 
 	loopProcess ifNil: [ ^self ].

--- a/FFICallLogger/TFLFunctionCyclicCounterAnnouncement.class.st
+++ b/FFICallLogger/TFLFunctionCyclicCounterAnnouncement.class.st
@@ -2,42 +2,44 @@
 I represent a completed cycle in a `TFLFunctionCyclicCounter`, and hold the relevant information.
 "
 Class {
-	#name : #TFLFunctionCyclicCounterAnnouncement,
-	#superclass : #Announcement,
+	#name : 'TFLFunctionCyclicCounterAnnouncement',
+	#superclass : 'Announcement',
 	#instVars : [
 		'functionNamesAndCounts',
 		'waitedMS',
 		'stopMS',
 		'startMS'
 	],
-	#category : #'FFICallLogger-Counter'
+	#category : 'FFICallLogger-Counter',
+	#package : 'FFICallLogger',
+	#tag : 'Counter'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLFunctionCyclicCounterAnnouncement >> countMSRatio [
 
 	^ waitedMS / self elapsedMS asFloat
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLFunctionCyclicCounterAnnouncement >> elapsedMS [
 
 	^ stopMS - startMS
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLFunctionCyclicCounterAnnouncement >> functionNamesAndCounts [
 
 	^ functionNamesAndCounts
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLFunctionCyclicCounterAnnouncement >> functionNamesAndCounts: anObject [
 
 	functionNamesAndCounts := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLFunctionCyclicCounterAnnouncement >> functionNamesAndCountsAdjusted [
 
 	| rows |
@@ -49,37 +51,37 @@ TFLFunctionCyclicCounterAnnouncement >> functionNamesAndCountsAdjusted [
 	^ rows	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLFunctionCyclicCounterAnnouncement >> startMS [
 
 	^ startMS
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLFunctionCyclicCounterAnnouncement >> startMS: anObject [
 
 	startMS := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLFunctionCyclicCounterAnnouncement >> stopMS [
 
 	^ stopMS
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLFunctionCyclicCounterAnnouncement >> stopMS: anObject [
 
 	stopMS := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLFunctionCyclicCounterAnnouncement >> waitedMS [
 
 	^ waitedMS
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLFunctionCyclicCounterAnnouncement >> waitedMS: anObject [
 
 	waitedMS := anObject

--- a/FFICallLogger/TFLNoAnswer.class.st
+++ b/FFICallLogger/TFLNoAnswer.class.st
@@ -4,21 +4,23 @@ I represent the answer of a call to a ""void"" function.
 I implement singleton via #instance in class-side, and provide specialized printing protocol.
 "
 Class {
-	#name : #TFLNoAnswer,
-	#superclass : #Object,
+	#name : 'TFLNoAnswer',
+	#superclass : 'Object',
 	#classInstVars : [
 		'instance'
 	],
-	#category : #'FFICallLogger-Recordings'
+	#category : 'FFICallLogger-Recordings',
+	#package : 'FFICallLogger',
+	#tag : 'Recordings'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLNoAnswer class >> instance [
 
 	^ instance ifNil: [ instance := self new ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 TFLNoAnswer >> printOn: aStream [
 
 	aStream nextPutAll: 'void'

--- a/FFICallLogger/TFLNullAddress.class.st
+++ b/FFICallLogger/TFLNullAddress.class.st
@@ -4,22 +4,24 @@ I represent the C NULL address.
 I implement singleton via `TFLNullAddress class >> #instance`, and provide specialized printing protocol.
 "
 Class {
-	#name : #TFLNullAddress,
-	#superclass : #Object,
-	#type : #bytes,
+	#name : 'TFLNullAddress',
+	#superclass : 'Object',
+	#type : 'bytes',
 	#classInstVars : [
 		'instance'
 	],
-	#category : #'FFICallLogger-Recordings'
+	#category : 'FFICallLogger-Recordings',
+	#package : 'FFICallLogger',
+	#tag : 'Recordings'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLNullAddress class >> instance [
 
 	^ instance ifNil: [ instance := self new ]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 TFLNullAddress >> printOn: aStream [
 
 	aStream nextPutAll: '@NULL'

--- a/FFICallLogger/TFLSessionCallsLogger.class.st
+++ b/FFICallLogger/TFLSessionCallsLogger.class.st
@@ -12,16 +12,18 @@ Easy steps to use it:
 
 "
 Class {
-	#name : #TFLSessionCallsLogger,
-	#superclass : #SignalLogger,
+	#name : 'TFLSessionCallsLogger',
+	#superclass : 'SignalLogger',
 	#instVars : [
 		'signalsWaitfreeQueue',
 		'session'
 	],
-	#category : #'FFICallLogger-Core'
+	#category : 'FFICallLogger-Core',
+	#package : 'FFICallLogger',
+	#tag : 'Core'
 }
 
-{ #category : #installation }
+{ #category : 'installation' }
 TFLSessionCallsLogger class >> logToFileAndQuit [
 	<script>
 
@@ -39,7 +41,7 @@ Log file written:
 
 ]
 
-{ #category : #installation }
+{ #category : 'installation' }
 TFLSessionCallsLogger class >> prepareAndQuit [
 	<script>
 
@@ -60,7 +62,7 @@ Log with something like:
 	Smalltalk snapshot: true andQuit: true.
 ]
 
-{ #category : #installation }
+{ #category : 'installation' }
 TFLSessionCallsLogger class >> script [
 
 [
@@ -82,7 +84,7 @@ s := World worldState worldRenderer actualScreenSize.
 			self logToFileAndQuit.] fork
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLSessionCallsLogger >> ensureQueueForCurrentSession [
 
 	(signalsWaitfreeQueue notNil and: [ session = SessionManager default currentSession ])
@@ -93,7 +95,7 @@ TFLSessionCallsLogger >> ensureQueueForCurrentSession [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLSessionCallsLogger >> flushSignals [
 	"Answer the recorded signals, and flush internal collection."
 
@@ -105,7 +107,7 @@ TFLSessionCallsLogger >> flushSignals [
 	^ results
 ]
 
-{ #category : #writing }
+{ #category : 'writing' }
 TFLSessionCallsLogger >> flushSignalsToNewFile [
 
 	| aFileReference |
@@ -119,7 +121,7 @@ TFLSessionCallsLogger >> flushSignalsToNewFile [
 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLSessionCallsLogger >> nextPut: aTFLSignal [
 
 	(self shouldLog: aTFLSignal) ifFalse: [ ^ self ].
@@ -130,7 +132,7 @@ TFLSessionCallsLogger >> nextPut: aTFLSignal [
 	signalsWaitfreeQueue nextPut: aTFLSignal
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 TFLSessionCallsLogger >> shouldLog: aTFLSignal [
 
 	| bannedFunctionNames |
@@ -139,14 +141,14 @@ TFLSessionCallsLogger >> shouldLog: aTFLSignal [
 	^ (bannedFunctionNames includes: aTFLSignal functionName) not
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLSessionCallsLogger >> start [
 
 	TFLSignal install.
 	self startFor: TFLSignal
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLSessionCallsLogger >> stop [
 
 	super stop.

--- a/FFICallLogger/TFLSignal.class.st
+++ b/FFICallLogger/TFLSignal.class.st
@@ -7,8 +7,8 @@ My instances have two states: ""initialized"" and ""prepared"". The method `TFLS
 
 "
 Class {
-	#name : #TFLSignal,
-	#superclass : #Announcement,
+	#name : 'TFLSignal',
+	#superclass : 'Announcement',
 	#instVars : [
 		'arguments',
 		'answer',
@@ -21,10 +21,12 @@ Class {
 	#classInstVars : [
 		'ffiInvokerMetalink'
 	],
-	#category : #'FFICallLogger-Core'
+	#category : 'FFICallLogger-Core',
+	#package : 'FFICallLogger',
+	#tag : 'Core'
 }
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 TFLSignal class >> emitWithContext: aContext answer: callAnswer voidCallClassName: aClassName functionTempName: functionTempVariableName argumentsTempName: argumentsTempVariableName [
 
 	| answerOrNoAnswer relevantStack aSignal |
@@ -47,7 +49,7 @@ TFLSignal class >> emitWithContext: aContext answer: callAnswer voidCallClassNam
 	aSignal emit
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 TFLSignal class >> emitWithContext: aContext answerAfterPharo11: callAnswer [
 
 	self
@@ -58,7 +60,7 @@ TFLSignal class >> emitWithContext: aContext answerAfterPharo11: callAnswer [
 		argumentsTempName: #aCollection
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 TFLSignal class >> emitWithContext: aContext answerBeforePharo11: callAnswer [
 
 	self
@@ -70,13 +72,13 @@ TFLSignal class >> emitWithContext: aContext answerBeforePharo11: callAnswer [
 
 ]
 
-{ #category : #installation }
+{ #category : 'installation' }
 TFLSignal class >> ffiInvokerASTNode [
 
 	^ self ffiInvokerMethod ast body statements last
 ]
 
-{ #category : #convenience }
+{ #category : 'convenience' }
 TFLSignal class >> ffiInvokerMethod [
 	"Answer the ThreadedFFI method where this signal installs."
 	<script: 'self ffiInvokerMethod browse'>
@@ -84,7 +86,7 @@ TFLSignal class >> ffiInvokerMethod [
 	^ TFSameThreadRunner>>#invokeFunction:withArguments:
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 TFLSignal class >> function: aFunction arguments: aCollection answer: anObject stack: anArrayOfContexts [
 
 	^ self basicNew
@@ -95,7 +97,7 @@ TFLSignal class >> function: aFunction arguments: aCollection answer: anObject s
 		  yourself
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 TFLSignal class >> initialize [
 
 	ffiInvokerMetalink := MetaLink new
@@ -108,7 +110,7 @@ TFLSignal class >> initialize [
 
 ]
 
-{ #category : #installation }
+{ #category : 'installation' }
 TFLSignal class >> install [
 	<script>
 
@@ -116,7 +118,7 @@ TFLSignal class >> install [
 		self ffiInvokerASTNode link: ffiInvokerMetalink ]
 ]
 
-{ #category : #installation }
+{ #category : 'installation' }
 TFLSignal class >> isInstalled [
 	"
 	self isInstalled
@@ -125,7 +127,7 @@ TFLSignal class >> isInstalled [
 	^ self ffiInvokerASTNode hasMetalink: ffiInvokerMetalink
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 TFLSignal class >> metalinkSelectorAccordingToPharoVersion [
 
 	^ SystemVersion current major < 11
@@ -133,7 +135,7 @@ TFLSignal class >> metalinkSelectorAccordingToPharoVersion [
 		ifFalse: [ #emitWithContext:answerAfterPharo11: ]
 ]
 
-{ #category : #installation }
+{ #category : 'installation' }
 TFLSignal class >> uninstall [
 	<script>
 
@@ -141,30 +143,30 @@ TFLSignal class >> uninstall [
 		self ffiInvokerASTNode removeLink: ffiInvokerMetalink ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLSignal >> answer [
 
 	^ answer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLSignal >> arguments [
 
 	^ arguments
 ]
 
-{ #category : #converting }
+{ #category : 'converting' }
 TFLSignal >> asBeaconSignal [
 	^ self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLSignal >> functionName [
 
 	^ functionName
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 TFLSignal >> initializeWithFunction: aFunction arguments: aCollection answer: anObject stack: anArrayOfContexts [
 
 	self initialize.
@@ -177,25 +179,25 @@ TFLSignal >> initializeWithFunction: aFunction arguments: aCollection answer: an
 	stack := anArrayOfContexts
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLSignal >> moduleName [
 
 	^ moduleName
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLSignal >> name [
 
 	^ 'FFI Call'
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 TFLSignal >> oneLineContents [
 
 	^ String streamContents: [ :s | self printOneLineContentsOn: s ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLSignal >> prepareAsRecording [
 	"Copy collaborators as an 'immutable' objects."
 
@@ -203,13 +205,13 @@ TFLSignal >> prepareAsRecording [
 	answer := answer asTFLRecording.
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 TFLSignal >> printOn: stream [
 
 	self printOneLineContentsOn: stream
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 TFLSignal >> printOneLineContentsOn: aStream [
 
 	aStream
@@ -227,32 +229,32 @@ TFLSignal >> printOneLineContentsOn: aStream [
 "
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLSignal >> processId [
 
 	^ processId
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLSignal >> sender [
 	"Answer the CompiledMethod that performed the call."
 
 	^ stack first method
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLSignal >> shortModuleName [
 
 	^ moduleName asPath basenameWithoutExtension
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLSignal >> stack [
 
 	^ stack
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 TFLSignal >> timestamp [
 	
 	^ DateAndTime fromMicrosecondClockValue: microsecondClockValue

--- a/FFICallLogger/package.st
+++ b/FFICallLogger/package.st
@@ -1,1 +1,1 @@
-Package { #name : #FFICallLogger }
+Package { #name : 'FFICallLogger' }


### PR DESCRIPTION
The shallow copy of the recordings was causing problems when trying to access those recordings from 'outside' de Logger.
By removing it, we are able to use the recordings :)

Example: 

In the [Wiki of BlocBenchs ](https://github.com/pharo-graphics/BlocBenchs/wiki), one of the examples is: 
```
[ case := BlBoidsProfileCase new.
case duration: 7 seconds.
case hostClass: BlOSWindowSDL2Host.
(BlProfileRunner newForCase: case)
   enableFPS;
   run;
   openMeterReports ] fork
```
Before the openMeterReports had no effect. It didn't show all the FFI Logs, now it does.

Of course, the same would happen with any other code that try to access the FFI Recordings.

